### PR TITLE
Fix deprecated "app.render()" signature

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -12,7 +12,7 @@ export function createExports(manifest) {
     const handler = async (request) => {
         const routeData = app.match(request);
         Reflect.set(request, clientAddressSymbol, request.headers.get('x-forwarded-for'));
-        const response = await app.render(request, routeData);
+        const response = await app.render(request, { routeData });
         if (app.setCookieHeaders) {
             for (const setCookieHeader of app.setCookieHeaders(response)) {
                 response.headers.append('Set-Cookie', setCookieHeader);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "astro-vercel-edge",
 	"description": "Deploy your Astro site to Vercel Edge Functions",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"type": "module",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
close #1 

Hey @mayank99 , I have modified "app.render" signature according to [the required form](https://github.com/withastro/astro/pull/9199). I have tested the changes, and they works well and no more throwing any errors.